### PR TITLE
Fix install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ curl -sSfL https://raw.githubusercontent.com/datanymizer/datanymizer/main/cli/
 $ curl -sSfL https://git.io/pg_datanymizer | sh -s
 
 # Specify installation directory and version
-$ curl -sSfL https://git.io/pg_datanymizer | sh -s -- -b usr/local/bin v0.2.0
+$ curl -sSfL https://git.io/pg_datanymizer | sudo sh -s -- -b /usr/local/bin v0.2.0
 
 # Alpine Linux (wget)
 $ wget -q -O - https://git.io/pg_datanymizer | sh -s


### PR DESCRIPTION
The command would install the binary in `usr/local/bin` in the current working directory, not in `/usr/local/bin`.

In order to install to `/usr/local/bin` you need sudo, so I added that as well