### PR TITLE
Replace `unwrap_or_else` with `unwrap_or_default`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Changed
 
 ### 🛠 Fixed
+- Replace `unwrap_or_else` with `unwrap_or_default` [#112](https://github.com/datanymizer/datanymizer/pull/112)
+  ([@mgrachev](https://github.com/mgrachev))
 
 ## [v0.4.0] - 2021-10-19
 ### 🚀 Added

--- a/datanymizer_engine/src/locale/mod.rs
+++ b/datanymizer_engine/src/locale/mod.rs
@@ -35,7 +35,7 @@ pub trait LocalizedFaker<V>: Localized {
     fn fake<L: ExtData>(&self, l: L) -> V;
 
     fn localized_fake(&self) -> V {
-        match self.locale().unwrap_or_else(LocaleConfig::default) {
+        match self.locale().unwrap_or_default() {
             LocaleConfig::EN => self.fake(EN {}),
             LocaleConfig::RU => self.fake(RU {}),
             LocaleConfig::ZH_TW => self.fake(ZH_TW {}),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✓ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/datanymizer/datanymizer/blob/master/CHANGELOG.md) (at the top of the list).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

This PR fixes a clippy warning:
```
error: use of `.unwrap_or_else(..)` to construct default value
  --> datanymizer_engine/src/locale/mod.rs:38:15
   |
38 |         match self.locale().unwrap_or_else(LocaleConfig::default) {
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `self.locale().unwrap_or_default()`
   |
   = note: `-D clippy::unwrap-or-else-default` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default

error: could not compile `datanymizer_engine` due to previous error
```

