### PR TITLE
pg_namespace to disambiguate repeated field name

### DIFF
--- a/datanymizer_dumper/src/postgres/schema_inspector.rs
+++ b/datanymizer_dumper/src/postgres/schema_inspector.rs
@@ -31,9 +31,11 @@ const TABLE_FOREIGN_KEYS: &str = "SELECT
 
 const TABLE_COLUMNS_QUERY: &str = "SELECT cc.column_name, cc.ordinal_position, cc.data_type, pt.oid
                                    FROM information_schema.columns as cc
-                                   JOIN pg_catalog.pg_type as pt
-                                   ON cc.udt_name = pt.typname
-                                   WHERE cc.table_schema = $1 and cc.table_name = $2
+                                        JOIN pg_catalog.pg_namespace as pn
+                                        ON cc.udt_schema = pn.nspname
+                                        JOIN pg_catalog.pg_type as pt
+                                        ON cc.udt_name = pt.typname AND pn.oid = pt.typnamespace
+                                   WHERE cc.table_schema = $1 and cc.table_name = $2                                   
                                    ORDER BY cc.ordinal_position ASC";
 
 const TABLE_SIZE_QUERY: &str =


### PR DESCRIPTION
This change fixes the TABLE_COLUMNS_QUERY to work as intended, but using pg_catalog.pg_namespace to disambiguate a case where the same name is used for a custom enum type in more than one schema (namespace) in the database.

Unfixed, this can result in `pg_datanymizer` building a list of columns with duplicate column names each time the name appears across all the namespaces.  The COPY command is rejected by postgres, and the run is aborted.

See [#148](https://github.com/datanymizer/datanymizer/issues/148) for more details.

Testable example:
[schema.dump.txt](https://github.com/datanymizer/datanymizer/files/8007333/schema.dump.txt)
[test2.yaml.txt](https://github.com/datanymizer/datanymizer/files/8007334/test2.yaml.txt)


<!-- _Please make sure to review and check all of these items:_ -->

#### ✓ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/datanymizer/datanymizer/blob/master/CHANGELOG.md) (at the top of the list);
- [ ] ??? Tests for the changes have been added (for bug fixes / features);  UNCLEAR HOW THIS CAN BE TESTED in the code, since it depends on the DB representation.
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
