### PR TITLE
#181 add tera filter sha256_hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tera",
  "thiserror",
  "time",

--- a/datanymizer_engine/Cargo.toml
+++ b/datanymizer_engine/Cargo.toml
@@ -25,4 +25,6 @@ time = { version = "0.3.7", features = ["local-offset", "formatting", "macros", 
 time-tz = "1.0.2"
 unicode-segmentation = "1.7.0"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
+sha2 = { version = "0.9.5" }
 wildmatch = "2.1.0"
+# hexfmt = { package = "hex", version = "0.4.3" }

--- a/datanymizer_engine/Cargo.toml
+++ b/datanymizer_engine/Cargo.toml
@@ -27,4 +27,3 @@ unicode-segmentation = "1.7.0"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 sha2 = { version = "0.9.5" }
 wildmatch = "2.1.0"
-# hexfmt = { package = "hex", version = "0.4.3" }

--- a/datanymizer_engine/src/transformers/template/hash_functions.rs
+++ b/datanymizer_engine/src/transformers/template/hash_functions.rs
@@ -4,8 +4,79 @@ use bcrypt::{hash, DEFAULT_COST};
 use serde_json::{from_value, Value};
 use tera::{try_get_value, Error, Result, Tera};
 
+use sha2::{Digest, Sha256};
+
 pub fn register(t: &mut Tera) {
     t.register_filter("bcrypt_hash", bcrypt_hash);
+    t.register_filter("sha256", sha256);
+}
+
+/// Sha256 hash function
+/// You can generate salted sha256 hashes with it
+///
+/// # Examples
+///
+/// ```yaml
+/// #...
+/// rules:
+///   some_value:
+///     template:
+///       format: "{{ _0 | sha256 }}"
+///
+///   some_value_more_confidential:
+///     template:
+///       format: "{{ _0 | sha256(rounds=10, salt='someverysecret') }}"
+///
+///   or_some_other_value:
+///     template:
+///       format: "{{ _0 | sha256(rounds=10, salt=secret_salt) }}"
+///
+///# you can concatenate this section in CI to avoid literal secrets
+/// globals:
+///   secret_salt: someverysecret
+/// ```
+fn sha256(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
+    let rounds: u32 = match args.get("rounds") {
+        Some(val) => match from_value::<u32>(val.clone()) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(Error::msg(format!(
+                    "Function `sha256` received rounds={} but `rounds` can only be an unsigned integer of 32bits",
+                    val
+                )));
+            }
+        },
+        None => 1,
+    };
+    let salt: String = match args.get("salt") {
+        Some(val) => match from_value::<String>(val.clone()) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(Error::msg(format!(
+                    "Function `sha256` received salt={} but `salt` can only be a string",
+                    val
+                )));
+            }
+        },
+        None => "".to_string(),
+    };
+
+    let val = try_get_value!("sha256", "value", String, value);
+
+    let mut hash: String = "".to_string();
+    for i in 0..rounds {
+        let mut sha256 = Sha256::new();
+        if i == 0 {
+            sha256.update(salt.clone());
+            sha256.update(val.clone());
+        } else {
+            sha256.update(salt.clone());
+            sha256.update(hash);
+        }
+        hash = format!("{:x}", sha256.finalize());
+    }
+
+    Ok(Value::from( hash.clone() ))
 }
 
 /// BCrypt hash function
@@ -79,5 +150,83 @@ mod tests {
         t.add_raw_template("empty_filter", &empty_template).unwrap();
         let real_value = t.render("empty_filter", &context).unwrap();
         assert!(verify(&pass, &real_value).unwrap());
+    }
+
+    #[test]
+    fn sha256_default() {
+        let mut t = Tera::default();
+        let mut context = Context::new();
+        let inp = "abc";
+        context.insert("value", inp);
+        register(&mut t);
+
+        let template = "{{ value | sha256 }}";
+        t.add_raw_template("empty_filter", &template).unwrap();
+
+        let real_value = t.render("empty_filter", &context).unwrap();
+
+        assert_eq!(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            &real_value,
+        );
+    }
+
+    #[test]
+    fn sha256_salt() {
+        let mut t = Tera::default();
+        let mut context = Context::new();
+        let inp = "abc";
+        context.insert("value", inp);
+        register(&mut t);
+
+        let template = "{{ value | sha256(salt='abcdef') }}";
+        t.add_raw_template("empty_filter", &template).unwrap();
+
+        let real_value = t.render("empty_filter", &context).unwrap();
+
+        assert_eq!(
+            "f9c8ac3b5d36269c49d88a3bec749842e0880625724d4896475639dc22ef5bf6",
+            &real_value,
+        );
+    }
+
+    #[test]
+    fn sha256_salt_rounds() {
+        let mut t = Tera::default();
+        let mut context = Context::new();
+        let inp = "abc";
+        context.insert("value", inp);
+        register(&mut t);
+
+        let template = "{{ value | sha256(salt='abcdef', rounds=5) }}";
+        t.add_raw_template("empty_filter", &template).unwrap();
+
+        let real_value = t.render("empty_filter", &context).unwrap();
+
+        assert_eq!(
+            "a0436350051508bc76278569ddd1f5d7d1868d0403c9a6895abed9949e5cf0c2",
+            &real_value,
+        );
+    }
+    #[test]
+    fn sha256_2salts_values_ne() {
+        let mut t = Tera::default();
+        let mut context = Context::new();
+        let inp = "abc";
+        context.insert("value", inp);
+        register(&mut t);
+
+        let template1 = "{{ value | sha256(salt='abc', rounds=5) }}";
+        t.add_raw_template("filter1", &template1).unwrap();
+        let real_value1 = t.render("filter1", &context).unwrap();
+
+        let template2 = "{{ value | sha256(salt='def', rounds=5) }}";
+        t.add_raw_template("filter2", &template2).unwrap();
+        let real_value2 = t.render("filter2", &context).unwrap();
+
+        assert_ne!(
+            &real_value1,
+            &real_value2,
+        );
     }
 }

--- a/datanymizer_engine/src/transformers/template/hash_functions.rs
+++ b/datanymizer_engine/src/transformers/template/hash_functions.rs
@@ -80,7 +80,7 @@ fn sha256_hash(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
         hash = format!("{:x}", sha256.finalize());
     }
 
-    Ok(Value::from( hash.clone() ))
+    Ok(Value::from(hash))
 }
 
 /// BCrypt hash function
@@ -229,9 +229,6 @@ mod tests {
         t.add_raw_template("filter2", &template2).unwrap();
         let real_value2 = t.render("filter2", &context).unwrap();
 
-        assert_ne!(
-            &real_value1,
-            &real_value2,
-        );
+        assert_ne!(&real_value1, &real_value2,);
     }
 }

--- a/datanymizer_engine/src/transformers/template/hash_functions.rs
+++ b/datanymizer_engine/src/transformers/template/hash_functions.rs
@@ -8,34 +8,38 @@ use sha2::{Digest, Sha256};
 
 pub fn register(t: &mut Tera) {
     t.register_filter("bcrypt_hash", bcrypt_hash);
-    t.register_filter("sha256", sha256);
+    t.register_filter("sha256_hash", sha256_hash);
 }
 
 /// Sha256 hash function
-/// You can generate salted sha256 hashes with it
+/// You can generate salted sha256 hashes with it. You may specify rounds of repeated hash function
+/// on its own results. You can specify your own salts. Depending on law you might need to throw
+/// the salt away or keep it only temporarily for an audit purpose. Use it when you may leak
+/// pseudoanonymized, traceable id's for debug purposes internally that must act like a primary
+/// key.
 ///
 /// # Examples
 ///
 /// ```yaml
 /// #...
 /// rules:
-///   some_value:
+///   some_field:
 ///     template:
-///       format: "{{ _0 | sha256 }}"
+///       format: "{{ _0 | sha256_hash }}"
 ///
-///   some_value_more_confidential:
+///   some_more_confidential_field:
 ///     template:
-///       format: "{{ _0 | sha256(rounds=10, salt='someverysecret') }}"
+///       format: "{{ _0 | sha256_hash(rounds=10, salt='someverysecret') }}"
 ///
-///   or_some_other_value:
+///   or_some_other_field:
 ///     template:
-///       format: "{{ _0 | sha256(rounds=10, salt=secret_salt) }}"
+///       format: "{{ _0 | sha256_hash(rounds=100, salt=secret_salt) }}"
 ///
-///# you can concatenate this section in CI to avoid literal secrets
+/// # you can concatenate the global section in CI to avoid literal secrets in config
 /// globals:
 ///   secret_salt: someverysecret
 /// ```
-fn sha256(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
+fn sha256_hash(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     let rounds: u32 = match args.get("rounds") {
         Some(val) => match from_value::<u32>(val.clone()) {
             Ok(v) => v,
@@ -160,7 +164,7 @@ mod tests {
         context.insert("value", inp);
         register(&mut t);
 
-        let template = "{{ value | sha256 }}";
+        let template = "{{ value | sha256_hash }}";
         t.add_raw_template("empty_filter", &template).unwrap();
 
         let real_value = t.render("empty_filter", &context).unwrap();
@@ -179,7 +183,7 @@ mod tests {
         context.insert("value", inp);
         register(&mut t);
 
-        let template = "{{ value | sha256(salt='abcdef') }}";
+        let template = "{{ value | sha256_hash(salt='abcdef') }}";
         t.add_raw_template("empty_filter", &template).unwrap();
 
         let real_value = t.render("empty_filter", &context).unwrap();
@@ -198,7 +202,7 @@ mod tests {
         context.insert("value", inp);
         register(&mut t);
 
-        let template = "{{ value | sha256(salt='abcdef', rounds=5) }}";
+        let template = "{{ value | sha256_hash(salt='abcdef', rounds=5) }}";
         t.add_raw_template("empty_filter", &template).unwrap();
 
         let real_value = t.render("empty_filter", &context).unwrap();
@@ -208,6 +212,7 @@ mod tests {
             &real_value,
         );
     }
+
     #[test]
     fn sha256_2salts_values_ne() {
         let mut t = Tera::default();
@@ -216,11 +221,11 @@ mod tests {
         context.insert("value", inp);
         register(&mut t);
 
-        let template1 = "{{ value | sha256(salt='abc', rounds=5) }}";
+        let template1 = "{{ value | sha256_hash(salt='abc', rounds=5) }}";
         t.add_raw_template("filter1", &template1).unwrap();
         let real_value1 = t.render("filter1", &context).unwrap();
 
-        let template2 = "{{ value | sha256(salt='def', rounds=5) }}";
+        let template2 = "{{ value | sha256_hash(salt='def', rounds=5) }}";
         t.add_raw_template("filter2", &template2).unwrap();
         let real_value2 = t.render("filter2", &context).unwrap();
 


### PR DESCRIPTION
This PR wants to add a new tera filter function for repeated sha256 hashes with an optional salt.

This intends not to be a solution for highly confidential secret, rather to provide a way of having a value in the output that can be verified when the salt is known.

For highly confidential values a more flexible hash should be used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✓ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] This PR has been added to [CHANGELOG.md](https://github.com/datanymizer/datanymizer/blob/master/CHANGELOG.md) (at the top of the list);
- [X] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
