### PR TITLE
transform_condition allow for null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 - Add the JSON transformer [#134](https://github.com/datanymizer/datanymizer/pull/134)
   ([@evgeniy-r](https://github.com/evgeniy-r))
+- transform_condition on nullable fields [#203](https://github.com/datanymizer/datanymizer/pull/203)
 
 ### ⚙️ Changed
 

--- a/datanymizer_dumper/src/postgres/table.rs
+++ b/datanymizer_dumper/src/postgres/table.rs
@@ -139,7 +139,11 @@ impl PgTable {
         match cfg {
             Some(c) => c.query.as_ref().and_then(|q| {
                 if q.transform_condition.is_some() {
-                    self.query_unless_already_dumped(q, |s| format!("NOT ({})", s), already_dumped)
+                    self.query_unless_already_dumped(
+                        q,
+                        |s| format!("((NOT ({})) OR (({}) IS NULL))", s, s),
+                        already_dumped,
+                    )
                 } else {
                     None
                 }
@@ -437,7 +441,7 @@ mod tests {
             );
             assert_eq!(
                 table().untransformed_query_to(Some(&cfg), 0).unwrap(),
-                "COPY (SELECT * FROM \"public\".\"some_table\" WHERE NOT (col1 = 'value')) TO STDOUT"
+                "COPY (SELECT * FROM \"public\".\"some_table\" WHERE ((NOT (col1 = 'value')) OR ((col1 = 'value') IS NULL))) TO STDOUT"
             );
             assert_eq!(table().count_of_query_to(Some(&cfg)), 1000);
         }
@@ -458,7 +462,7 @@ mod tests {
             assert_eq!(
                 table().untransformed_query_to(Some(&cfg), 0).unwrap(),
                 "COPY (SELECT * FROM \"public\".\"some_table\" \
-                WHERE (col1 = 'value') AND NOT (col2 <> 'other_value') LIMIT 500) TO STDOUT"
+                WHERE (col1 = 'value') AND ((NOT (col2 <> 'other_value')) OR ((col2 <> 'other_value') IS NULL)) LIMIT 500) TO STDOUT"
             );
             assert_eq!(table().count_of_query_to(Some(&cfg)), 500);
         }
@@ -480,7 +484,7 @@ mod tests {
                 );
                 assert_eq!(
                     table().untransformed_query_to(Some(&cfg), 100).unwrap(),
-                    "COPY (SELECT * FROM \"public\".\"some_table\" WHERE NOT (col1 = 'value')) TO STDOUT"
+                    "COPY (SELECT * FROM \"public\".\"some_table\" WHERE ((NOT (col1 = 'value')) OR ((col1 = 'value') IS NULL))) TO STDOUT"
                 );
             }
 
@@ -498,7 +502,7 @@ mod tests {
                 );
                 assert_eq!(
                     table().untransformed_query_to(Some(&cfg), 100).unwrap(),
-                    "COPY (SELECT * FROM \"public\".\"some_table\" WHERE NOT (col1 = 'value') LIMIT 50) TO STDOUT"
+                    "COPY (SELECT * FROM \"public\".\"some_table\" WHERE ((NOT (col1 = 'value')) OR ((col1 = 'value') IS NULL)) LIMIT 50) TO STDOUT"
                 );
             }
 


### PR DESCRIPTION
A transform_condition that operates on a nullable field has 3 states rather than two.
The existing 2 query system can leave one of the states out of the dump.
Have the NOT version of the query perform an IS NULL check.

#### ✓ Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/datanymizer/datanymizer/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
