### PR TITLE
Add `null` transformer to clear field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add `default.preserve_null` option to keep NULL values (`\N`) as-is instead of transforming them.
+- Add wildcard patterns for table names and column rules. Use `name: "public.*"` to match all
+  tables in a schema, `names: ["A.*", "B.*"]` to target multiple schemas, and `"*iban"` in column
+  rules to anonymize every column ending in `iban`. Exact matches always take priority over wildcards.
 - Add SQL assertions in `config.yml` with support for global and table-level checks, row-based
   expectations (`no_rows`, `rows_exist`), scalar comparisons (`eq`, `not_eq`, `gt`, `gte`, `lt`,
   `lte`), and integration tests for PostgreSQL execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add `null` transformer to explicitly set field values to NULL (`\N` in PostgreSQL COPY format).
 - Add SQL assertions in `config.yml` with support for global and table-level checks, row-based
   expectations (`no_rows`, `rows_exist`), scalar comparisons (`eq`, `not_eq`, `gt`, `gte`, `lt`,
   `lte`), and integration tests for PostgreSQL execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add wildcard patterns for table names. Use `name: "public.*"` to match all tables in a schema,
+  or `names: ["A.*", "B.*"]` to apply the same rules across multiple schemas. Exact matches always
+  take priority over wildcards. When a table is matched via wildcard, column rules for columns that
+  don't exist are silently skipped; exact table matches keep strict column validation.
+- Add `--dry-run` flag to preview which tables and columns would be anonymized without running a
+  dump. Reports misconfigured entries (matched table with no existing columns) as errors.
 - Add SQL assertions in `config.yml` with support for global and table-level checks, row-based
   expectations (`no_rows`, `rows_exist`), scalar comparisons (`eq`, `not_eq`, `gt`, `gte`, `lt`,
   `lte`), and integration tests for PostgreSQL execution.
@@ -14,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run assertions as part of the dumper lifecycle before dump generation starts, while keeping the
   comparison semantics and validation logic inside `datanymizer_engine`.
 - Extend configuration and CLI documentation with assertion examples and release-ready usage notes.
+- CLI now prints clean error messages without stack traces on failure.
 
 ### 🛠 Fixed
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ globals:
 | `city`                         | City names generator                                                         |
 | `phone`                        | Generate random phone with different `format`                                |
 | `pipeline`                     | Use pipeline to generate more complicated values                             |
+| `null`                         | Sets the field value to NULL                                                 |
 | `capitalize`                   | Like filter, it capitalizes input value                                      |
 | `template`                     | Template engine for generate random text with included rules                 |
 | `digit`                        | Random digit (in range `0..9`)                                               |

--- a/README.md
+++ b/README.md
@@ -246,6 +246,67 @@ You can use wildcards in the `filter` section:
 * `?` matches exactly one occurrence of any character;
 * `*` matches arbitrary many (including zero) occurrences of any character.
 
+For example, to skip all tables in the `audit` schema and dump only `public.user*` tables:
+
+```yaml
+# config.yml
+#...
+filter:
+  data:
+    only:
+      - "public.user*"
+  schema:
+    except:
+      - "audit.*"
+```
+
+### Wildcard patterns in table names
+
+Table names support wildcard patterns (`*`, `?`). Anonymize all tables in a schema:
+
+```yaml
+# config.yml
+tables:
+  - name: "public.*"
+    rules:
+      email:
+        email: {}
+```
+
+Apply the same rules to tables across multiple schemas with `names`:
+
+```yaml
+# config.yml
+tables:
+  - names: ["schema_a.*", "schema_b.*"]
+    rules:
+      email:
+        email: {}
+```
+
+Exact table entries always take priority over wildcards. When a table is matched by a wildcard,
+column rules for columns that don't exist are silently skipped:
+
+```yaml
+# config.yml
+tables:
+  # Wildcard: applies to all public tables (missing columns silently skipped)
+  - name: "public.*"
+    rules:
+      email:
+        email: {}
+
+  # Exact: overrides the wildcard for public.users
+  - name: public.users
+    rules:
+      email:
+        email:
+          uniq: true
+```
+
+Either `name` or `names` must be provided (not both). For the full specification see
+[config.yml](docs/config.md).
+
 ### Dump conditions and limit
 
 You can specify conditions (SQL `WHERE` statement) and limit for dumped data per table:

--- a/cli/pg_datanymizer/src/app.rs
+++ b/cli/pg_datanymizer/src/app.rs
@@ -9,7 +9,7 @@ use crate::options::{Options, TransactionConfig};
 
 use datanymizer_dumper::{
     indicator::{ConsoleIndicator, Indicator, SilentIndicator},
-    postgres::{connector::Connector, dumper::PgDumper, IsolationLevel},
+    postgres::{connector::Connector, dry_run, dumper::PgDumper, IsolationLevel},
     Dumper,
 };
 use datanymizer_engine::{Engine, Settings};
@@ -30,6 +30,12 @@ impl App {
     }
 
     pub fn run(&self) -> Result<()> {
+        if self.options.dry_run {
+            let mut connection = self.connector().connect()?;
+            let mut settings = Settings::new(self.options.config.clone())?;
+            return dry_run::run(&mut connection, &mut settings);
+        }
+
         match (&self.options.file, &self.options.no_indicator) {
             (Some(filename), false) => {
                 self.make_dump(File::create(filename)?, ConsoleIndicator::new())

--- a/cli/pg_datanymizer/src/main.rs
+++ b/cli/pg_datanymizer/src/main.rs
@@ -7,7 +7,7 @@ use options::Options;
 mod app;
 mod options;
 
-fn main() -> Result<()> {
+fn main() {
     let options = Options::parse();
 
     env_logger::init_from_env(env_logger::Env::default().filter_or(
@@ -21,6 +21,13 @@ fn main() -> Result<()> {
         },
     ));
 
+    if let Err(err) = run(options) {
+        eprintln!("Error: {err:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run(options: Options) -> Result<()> {
     let app = App::from_options(options)?;
     app.run()
 }

--- a/cli/pg_datanymizer/src/options.rs
+++ b/cli/pg_datanymizer/src/options.rs
@@ -123,6 +123,12 @@ pub struct Options {
 
     #[arg(long, name = "no-indicator", help = "Disable indicator")]
     pub no_indicator: bool,
+
+    #[arg(
+        long,
+        help = "Dry-run: show anonymization plan without dumping data"
+    )]
+    pub dry_run: bool,
 }
 
 impl Options {

--- a/datanymizer_dumper/src/postgres/dry_run.rs
+++ b/datanymizer_dumper/src/postgres/dry_run.rs
@@ -1,0 +1,79 @@
+use super::{connector, schema_inspector::PgSchemaInspector};
+use crate::{SchemaInspector, Table};
+use anyhow::Result;
+use datanymizer_engine::Settings;
+
+pub fn run(connection: &mut connector::Connection, settings: &mut Settings) -> Result<()> {
+    let inspector = PgSchemaInspector {};
+    let tables = inspector.get_tables(connection)?;
+
+    for table in &tables {
+        settings.register_table_transforms(
+            &table.get_full_name(),
+            &table.get_name(),
+            &table.get_columns_names(),
+        );
+    }
+
+    let mut matched: Vec<(String, String, Vec<String>)> = Vec::new();
+    let mut unmatched: Vec<String> = Vec::new();
+    let mut no_cols: Vec<String> = Vec::new();
+
+    for table in &tables {
+        let full_name = table.get_full_name();
+        let names = table.get_names();
+        let actual_columns = table.get_columns_names();
+
+        match settings.dry_run_info(&full_name, &names) {
+            Some((rule_label, cols)) => {
+                // Filter to columns that actually exist in this table
+                let existing: Vec<String> = cols
+                    .into_iter()
+                    .filter(|c| actual_columns.contains(c))
+                    .collect();
+                if !existing.is_empty() {
+                    matched.push((full_name, rule_label, existing));
+                } else {
+                    no_cols.push(full_name);
+                }
+            }
+            None => unmatched.push(full_name),
+        }
+    }
+
+    let matched_name_width = matched
+        .iter()
+        .map(|(n, _, _)| n.len())
+        .max()
+        .unwrap_or(0);
+
+    let rule_width = matched
+        .iter()
+        .map(|(_, r, _)| r.len())
+        .max()
+        .unwrap_or(0);
+
+    for (full_name, rule_label, cols) in &matched {
+        let col_str = cols.join("  ");
+        println!("{full_name:<matched_name_width$}  [{rule_label:<rule_width$}]  {col_str}");
+    }
+
+    if !unmatched.is_empty() {
+        let count = unmatched.len();
+        println!("\n── unmatched ({count}) ──");
+        for name in &unmatched {
+            println!("  {name}");
+        }
+    }
+
+    if !no_cols.is_empty() {
+        let count = no_cols.len();
+        eprintln!("\nerror: {count} configured table(s) have no matching columns:");
+        for name in &no_cols {
+            eprintln!("  {name}");
+        }
+        anyhow::bail!("config validation failed: no columns matched");
+    }
+
+    Ok(())
+}

--- a/datanymizer_dumper/src/postgres/dumper.rs
+++ b/datanymizer_dumper/src/postgres/dumper.rs
@@ -78,36 +78,67 @@ impl<W: 'static + Write + Send, I: 'static + Indicator + Send> PgDumper<W, I> {
 
     fn dump_table(&mut self, table: &PgTable, qw: &mut QueryWrapper) -> Result<()> {
         let started = Instant::now();
+        let full_name = table.get_full_name();
 
-        self.write_log(format!("Dump table: {}", &table.get_full_name()))?;
+        self.write_log(format!("Dump table: {}", &full_name))?;
 
         self.dump_writer.write_all(b"\n")?;
         self.dump_writer.write_all(table.query_from().as_bytes())?;
         self.dump_writer.write_all(b"\n")?;
 
-        let cfg = self.engine.settings.find_table(&table.get_names());
+        let matched_cfg = self.engine.settings.find_table(&table.get_names());
+
+        // Determine the transform_map key: for wildcard/names entries, use the
+        // full table name (registered by register_table_transforms); for exact
+        // entries, use the config name.
+        let transform_key = matched_cfg
+            .map(|c| {
+                if c.has_wildcards() || c.name.is_empty() {
+                    full_name.clone()
+                } else {
+                    c.name.clone()
+                }
+            })
+            .unwrap_or_default();
+
+        let has_transforms = self
+            .engine
+            .settings
+            .transformers_for(&transform_key)
+            .is_some_and(|t| !t.is_empty());
+
+        // For wildcard config entries with no matching columns, treat as no config
+        let cfg = if has_transforms {
+            matched_cfg
+        } else if matched_cfg.is_some_and(|c| c.has_wildcards() || c.name.is_empty()) {
+            None
+        } else {
+            matched_cfg
+        };
 
         self.indicator
-            .start_pb(table.count_of_query_to(cfg), &table.get_full_name());
+            .start_pb(table.count_of_query_to(cfg), &full_name);
 
         let mut count: u64 = 0;
-        if let Some(cfg) = cfg {
-            if let Some(transformed_query) = table.transformed_query_to(Some(cfg), count) {
-                let reader = qw.copy_out(transformed_query.as_str())?;
-                for line in reader.lines() {
-                    self.indicator.inc_pb(1);
+        if has_transforms {
+            if let Some(cfg) = cfg {
+                if let Some(transformed_query) = table.transformed_query_to(Some(cfg), count) {
+                    let reader = qw.copy_out(transformed_query.as_str())?;
+                    for line in reader.lines() {
+                        self.indicator.inc_pb(1);
 
-                    let row = PgRow::from_string_row(line?, table.clone());
-                    let transformed =
-                        row.transform(&self.engine, cfg.name.as_str())
+                        let row = PgRow::from_string_row(line?, table.clone());
+                        let transformed = row
+                            .transform(&self.engine, transform_key.as_str())
                             .map_err(|err| {
                                 warn!("{:#?}", err);
                                 err
                             })?;
-                    self.dump_writer.write_all(transformed.as_bytes())?;
-                    self.dump_writer.write_all(b"\n")?;
+                        self.dump_writer.write_all(transformed.as_bytes())?;
+                        self.dump_writer.write_all(b"\n")?;
 
-                    count += 1;
+                        count += 1;
+                    }
                 }
             }
         }
@@ -157,6 +188,18 @@ impl<W: 'static + Write + Send, I: 'static + Indicator + Send> Dumper for PgDump
     // This stage makes dump data only
     fn data(&mut self, connection: &mut Self::Connection) -> Result<()> {
         self.write_log("Start dumping data".into())?;
+
+        // Resolve wildcard table/column rules against actual table metadata
+        let table_info: Vec<_> = self
+            .tables
+            .iter()
+            .map(|t| (t.get_full_name(), t.get_name(), t.get_columns_names()))
+            .collect();
+        for (full_name, short_name, columns) in &table_info {
+            self.engine
+                .settings
+                .register_table_transforms(full_name, short_name, columns);
+        }
 
         let all_tables_count = self.tables.len();
 

--- a/datanymizer_dumper/src/postgres/mod.rs
+++ b/datanymizer_dumper/src/postgres/mod.rs
@@ -1,6 +1,7 @@
 use crate::SchemaInspector;
 
 pub mod asserts;
+pub mod dry_run;
 pub mod column;
 pub mod connector;
 pub mod dumper;

--- a/datanymizer_dumper/src/postgres/table.rs
+++ b/datanymizer_dumper/src/postgres/table.rs
@@ -337,6 +337,7 @@ mod tests {
         fn cfg(query: Option<QueryCfg>) -> TableCfg {
             TableCfg {
                 name: table_name(),
+                names: None,
                 rules: HashMap::new(),
                 rule_order: None,
                 query,

--- a/datanymizer_engine/src/engine.rs
+++ b/datanymizer_engine/src/engine.rs
@@ -29,6 +29,10 @@ impl Engine {
         if let Some(ts) = ts {
             for (field, tr) in ts {
                 if let Some(&i) = column_indexes.get(field) {
+                    if values[i] == "\\N" && self.settings.default.preserve_null {
+                        continue;
+                    }
+
                     match tr.transform(
                         &format!("{}.{}", table, field),
                         values[i],
@@ -98,6 +102,60 @@ mod tests {
         assert_eq!(tr_values[2], "");
         assert_eq!(tr_values[3], "");
         assert_ne!(tr_values[4], "");
+    }
+
+    #[test]
+    fn preserve_null_keeps_null_values() {
+        let config = r#"
+          source: {}
+          default:
+            preserve_null: true
+          tables:
+            - name: actor
+              rules:
+                first_name:
+                  first_name: {}
+        "#;
+        let settings = Settings::from_yaml(config).unwrap();
+
+        let table = String::from("actor");
+        let values = vec!["\\N"];
+
+        let mut column_indexes = HashMap::new();
+        column_indexes.insert(String::from("first_name"), 0);
+
+        let tr_values = Engine::new(settings)
+            .process_row(table, &column_indexes, &values)
+            .unwrap();
+
+        assert_eq!(tr_values[0], "\\N");
+    }
+
+    #[test]
+    fn preserve_null_still_transforms_non_null() {
+        let config = r#"
+          source: {}
+          default:
+            preserve_null: true
+          tables:
+            - name: actor
+              rules:
+                first_name:
+                  capitalize: ~
+        "#;
+        let settings = Settings::from_yaml(config).unwrap();
+
+        let table = String::from("actor");
+        let values = vec!["hello"];
+
+        let mut column_indexes = HashMap::new();
+        column_indexes.insert(String::from("first_name"), 0);
+
+        let tr_values = Engine::new(settings)
+            .process_row(table, &column_indexes, &values)
+            .unwrap();
+
+        assert_eq!(tr_values[0], "Hello");
     }
 
     mod row_refs {

--- a/datanymizer_engine/src/settings/mod.rs
+++ b/datanymizer_engine/src/settings/mod.rs
@@ -13,6 +13,7 @@ use config::{Config, ConfigError, File, FileFormat};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+use wildmatch::WildMatch;
 
 pub use filter::{Filter, TableList};
 pub use r#assert::{
@@ -73,9 +74,31 @@ impl Settings {
         let c = Config::builder().add_source(source).build()?;
 
         let mut settings: Self = c.try_deserialize()?;
+        settings.validate()?;
         settings.preprocess();
 
         Ok(settings)
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        for (i, table) in self.tables.iter().enumerate() {
+            let has_name = !table.name.is_empty();
+            let has_names = table.names.as_ref().is_some_and(|n| !n.is_empty());
+
+            if has_name && has_names {
+                return Err(ConfigError::Message(format!(
+                    "tables[{}]: cannot specify both `name` and `names` — use one or the other",
+                    i
+                )));
+            }
+            if !has_name && !has_names {
+                return Err(ConfigError::Message(format!(
+                    "tables[{}]: must specify either `name` or `names`",
+                    i
+                )));
+            }
+        }
+        Ok(())
     }
 
     pub fn transformers_for(&self, table: &str) -> Option<&TransformList> {
@@ -88,6 +111,40 @@ impl Settings {
 
     pub fn get_table(&self, name: &str) -> Option<&Table> {
         self.tables.iter().find(|t| t.name == name)
+    }
+
+    /// For a table that has been registered via [`register_table_transforms`], returns:
+    /// - the display label of the config rule that matched it (e.g. `public.*`)
+    /// - the list of anonymized column names
+    ///
+    /// Returns `None` if no config rule matches or no columns are anonymized.
+    pub fn dry_run_info<T: AsRef<str>>(
+        &self,
+        full_name: &str,
+        names: &[T],
+    ) -> Option<(String, Vec<String>)> {
+        let table_cfg = self.find_table(names)?;
+        let transform_key = if table_cfg.has_wildcards() || table_cfg.name.is_empty() {
+            full_name.to_string()
+        } else {
+            table_cfg.name.clone()
+        };
+
+        let transforms = self.transformers_for(&transform_key)?;
+        if transforms.is_empty() {
+            return None;
+        }
+
+        let rule_label = table_cfg
+            .patterns()
+            .into_iter()
+            .find(|pat| names.iter().any(|n| WildMatch::new(pat).matches(n.as_ref())))
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| table_cfg.name.clone());
+
+        let columns = transforms.iter().map(|(col_name, _)| col_name.clone()).collect();
+
+        Some((rule_label, columns))
     }
 
     /// Returns global and table-local assertions in execution order.
@@ -107,14 +164,94 @@ impl Settings {
         asserts
     }
 
+    /// Finds a table config matching any of the given candidate names.
+    /// First tries exact match (preserving backward compatibility),
+    /// then tries wildcard patterns.
     pub fn find_table<T: AsRef<str>>(&self, names: &[T]) -> Option<&Table> {
+        self.find_table_match(names).map(|(table, _)| table)
+    }
+
+    /// Like `find_table`, but also returns whether the match was via a wildcard pattern.
+    fn find_table_match<T: AsRef<str>>(&self, names: &[T]) -> Option<(&Table, bool)> {
+        // Pass 1: exact match (existing behavior)
         for name in names {
             let table = self.get_table(name.as_ref());
             if table.is_some() {
-                return table;
+                return table.map(|t| (t, false));
             }
         }
+
+        // Pass 2: pattern match — covers wildcard entries and `names` entries
+        // (even non-wildcard `names` entries, since pass 1 only checks `name` field)
+        for table_cfg in &self.tables {
+            if table_cfg.names.is_none() && !table_cfg.has_wildcards() {
+                continue;
+            }
+            let is_wild = |s: &str| s.contains('*') || s.contains('?');
+            for pattern in table_cfg.patterns() {
+                let matcher = WildMatch::new(pattern);
+                for name in names {
+                    if matcher.matches(name.as_ref()) {
+                        return Some((table_cfg, is_wild(pattern)));
+                    }
+                }
+            }
+        }
+
         None
+    }
+
+    /// Registers resolved transforms for a discovered table, resolving wildcard
+    /// table name patterns against actual table metadata.
+    /// Called from the dumper after table/column metadata is known.
+    pub fn register_table_transforms(
+        &mut self,
+        full_name: &str,
+        short_name: &str,
+        actual_columns: &[String],
+    ) {
+        // Skip if already resolved by fill_transform_map (exact table)
+        if let Some(map) = &self.transform_map {
+            if map.contains_key(full_name) || map.contains_key(short_name) {
+                return;
+            }
+        }
+
+        let names = [full_name, short_name];
+        let table_match = self.find_table_match(&names).map(|(t, w)| (t.clone(), w));
+
+        if let Some((cfg, matched_via_wildcard)) = table_match {
+            let transform_list = if matched_via_wildcard {
+                // Wildcard table: silently skip rules for columns that don't exist
+                let explicit_rule_order = cfg.rule_order.clone().unwrap_or_default();
+                let mut list: TransformList = cfg
+                    .rules
+                    .iter()
+                    .filter(|(col, _)| actual_columns.contains(col))
+                    .map(|(col, t)| (col.clone(), t.clone()))
+                    .collect();
+                list.sort_by_cached_key(|(key, _)| {
+                    explicit_rule_order.iter().position(|i| i == key)
+                });
+                list
+            } else {
+                // Exact table (via names field): use all rules as-is
+                cfg.transform_list()
+            };
+
+            if transform_list.is_empty() {
+                return;
+            }
+
+            let map = self.transform_map.get_or_insert_with(HashMap::new);
+            // Use the config name for exact entries, full_name for wildcard/names entries
+            let key = if cfg.name.is_empty() || matched_via_wildcard {
+                full_name.to_string()
+            } else {
+                cfg.name.clone()
+            };
+            map.insert(key, transform_list);
+        }
     }
 
     fn preprocess(&mut self) {
@@ -137,12 +274,19 @@ impl Settings {
     fn fill_transform_map(&mut self) {
         let mut map = HashMap::with_capacity(self.tables.len());
         for table in &self.tables {
+            // Only pre-resolve entries with an exact table name.
+            // Wildcard/names entries are deferred to register_table_transforms()
+            // at dump time when actual table metadata is available.
+            if table.names.is_some() || table.has_wildcards() {
+                continue;
+            }
             map.insert(table.name.clone(), table.transform_list());
         }
 
         self.transform_map = Some(map);
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -360,5 +504,388 @@ mod tests {
                 lte: None,
             }))
         );
+    }
+
+    mod validation {
+        use super::*;
+
+        #[test]
+        fn rejects_both_name_and_names() {
+            let config = r#"
+                tables:
+                  - name: "public.users"
+                    names:
+                      - "A.*"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let err = Settings::from_yaml(config).unwrap_err();
+            assert!(
+                err.to_string().contains("cannot specify both"),
+                "Expected 'cannot specify both' error, got: {}",
+                err
+            );
+        }
+
+        #[test]
+        fn rejects_neither_name_nor_names() {
+            let config = r#"
+                tables:
+                  - rules:
+                      email:
+                        person_name: {}
+                "#;
+            let err = Settings::from_yaml(config).unwrap_err();
+            assert!(
+                err.to_string().contains("must specify either"),
+                "Expected 'must specify either' error, got: {}",
+                err
+            );
+        }
+
+        #[test]
+        fn rejects_empty_names_list() {
+            let config = r#"
+                tables:
+                  - names: []
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let err = Settings::from_yaml(config).unwrap_err();
+            assert!(
+                err.to_string().contains("must specify either"),
+                "Expected 'must specify either' error, got: {}",
+                err
+            );
+        }
+    }
+
+    mod wildcard_table_matching {
+        use super::*;
+
+        #[test]
+        fn wildcard_name_matches() {
+            let config = r#"
+                tables:
+                  - name: "public.*"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            let t = s.find_table(&["public.users"]);
+            assert!(t.is_some());
+
+            let t = s.find_table(&["other.users"]);
+            assert!(t.is_none());
+        }
+
+        #[test]
+        fn exact_match_beats_wildcard() {
+            let config = r#"
+                tables:
+                  - name: "public.*"
+                    rules:
+                      email:
+                        person_name: {}
+                  - name: public.users
+                    rules:
+                      email:
+                        first_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            // Exact match should win
+            let t = s.find_table(&["public.users", "users"]);
+            assert_eq!(t.unwrap().name, "public.users");
+
+            // Wildcard should match other tables
+            let t = s.find_table(&["public.orders", "orders"]);
+            assert_eq!(t.unwrap().name, "public.*");
+        }
+
+        #[test]
+        fn names_field_with_multiple_patterns() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "A.*"
+                      - "B.*"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            assert!(s.find_table(&["A.users"]).is_some());
+            assert!(s.find_table(&["B.orders"]).is_some());
+            assert!(s.find_table(&["C.stuff"]).is_none());
+        }
+
+        #[test]
+        fn first_wildcard_entry_wins() {
+            let config = r#"
+                tables:
+                  - name: "public.*"
+                    rules:
+                      email:
+                        person_name: {}
+                  - name: "public.u*"
+                    rules:
+                      email:
+                        first_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            // First wildcard entry should win
+            let t = s.find_table(&["public.users"]);
+            assert_eq!(t.unwrap().name, "public.*");
+        }
+
+        #[test]
+        fn names_field_with_exact_values() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "A.users"
+                      - "B.orders"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            assert!(s.find_table(&["A.users"]).is_some());
+            assert!(s.find_table(&["B.orders"]).is_some());
+            assert!(s.find_table(&["A.orders"]).is_none());
+        }
+
+        #[test]
+        fn backward_compat_no_wildcards() {
+            let config = r#"
+                tables:
+                  - name: users
+                    rules:
+                      name:
+                        person_name: {}
+                "#;
+            let s = Settings::from_yaml(config).unwrap();
+
+            let t = s.find_table(&["public.users", "users"]);
+            assert_eq!(t.unwrap().name, "users");
+        }
+    }
+
+    mod register_table_transforms_tests {
+        use super::*;
+
+        fn transform_keys(s: &Settings, table: &str) -> Vec<String> {
+            match s.transformers_for(table) {
+                Some(list) => list.iter().map(|(name, _)| name.clone()).collect(),
+                None => vec![],
+            }
+        }
+
+        #[test]
+        fn exact_table_not_overwritten() {
+            let config = r#"
+                tables:
+                  - name: users
+                    rules:
+                      name:
+                        person_name: {}
+                  - name: "public.*"
+                    rules:
+                      email:
+                        first_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // Exact table already in transform_map from fill_transform_map
+            let keys = transform_keys(&s, "users");
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains(&"name".to_string()));
+
+            // register_table_transforms should not overwrite it
+            s.register_table_transforms(
+                "public.users",
+                "users",
+                &["name".to_string(), "email".to_string()],
+            );
+
+            // Still the exact-match entry
+            let keys = transform_keys(&s, "users");
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains(&"name".to_string()));
+        }
+
+        #[test]
+        fn names_field_registers_correctly() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "A.*"
+                      - "B.*"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            s.register_table_transforms(
+                "A.users",
+                "users",
+                &["id".to_string(), "email".to_string()],
+            );
+            s.register_table_transforms(
+                "B.orders",
+                "orders",
+                &["id".to_string(), "email".to_string()],
+            );
+
+            let keys_a = transform_keys(&s, "A.users");
+            assert_eq!(keys_a.len(), 1);
+            assert!(keys_a.contains(&"email".to_string()));
+
+            let keys_b = transform_keys(&s, "B.orders");
+            assert_eq!(keys_b.len(), 1);
+            assert!(keys_b.contains(&"email".to_string()));
+        }
+
+        #[test]
+        fn wildcard_table_exact_column_missing_silently_skipped() {
+            let config = r#"
+                tables:
+                  - name: "public.*"
+                    rules:
+                      email:
+                        person_name: {}
+                      phone:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // Table has email but not phone — phone should be silently skipped
+            s.register_table_transforms(
+                "public.logs",
+                "logs",
+                &["id".to_string(), "email".to_string()],
+            );
+
+            let keys = transform_keys(&s, "public.logs");
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains(&"email".to_string()));
+            assert!(!keys.contains(&"phone".to_string()));
+        }
+
+        #[test]
+        fn names_mixed_exact_and_wildcard_strict_for_exact_match() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "_sqlx_migrations"
+                      - "ok*"
+                    rules:
+                      description:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // _sqlx_migrations matches via exact pattern — should keep
+            // missing exact columns (strict mode)
+            s.register_table_transforms(
+                "public._sqlx_migrations",
+                "_sqlx_migrations",
+                &["id".to_string(), "version".to_string()],
+            );
+
+            // "description" doesn't exist but should be kept (exact table match)
+            let keys = transform_keys(&s, "public._sqlx_migrations");
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains(&"description".to_string()));
+        }
+
+        #[test]
+        fn names_mixed_exact_and_wildcard_lenient_for_wildcard_match() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "_sqlx_migrations"
+                      - "ok*"
+                    rules:
+                      description:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // ok_stuff matches via wildcard pattern — should silently skip
+            // missing columns (lenient mode)
+            s.register_table_transforms(
+                "public.ok_stuff",
+                "ok_stuff",
+                &["id".to_string(), "name".to_string()],
+            );
+
+            // "description" doesn't exist and should be skipped (wildcard table match)
+            assert!(s.transformers_for("public.ok_stuff").is_none());
+        }
+
+        #[test]
+        fn overlapping_wildcards_first_entry_wins() {
+            let config = r#"
+                tables:
+                  - name: "public.*"
+                    rules:
+                      email:
+                        person_name: {}
+                  - name: "*users*"
+                    rules:
+                      phone:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // Both patterns match public.users — first entry (public.*) should win
+            s.register_table_transforms(
+                "public.users",
+                "users",
+                &["email".to_string(), "phone".to_string()],
+            );
+
+            let keys = transform_keys(&s, "public.users");
+            // Should have email (from public.*), not phone (from *users*)
+            assert!(keys.contains(&"email".to_string()));
+            assert!(!keys.contains(&"phone".to_string()));
+        }
+
+        #[test]
+        fn names_field_exact_values_registers_correctly() {
+            let config = r#"
+                tables:
+                  - names:
+                      - "A.users"
+                      - "B.users"
+                    rules:
+                      email:
+                        person_name: {}
+                "#;
+            let mut s = Settings::from_yaml(config).unwrap();
+
+            // Should not be in transform_map from fill_transform_map
+            assert!(s.transformers_for("A.users").is_none());
+
+            s.register_table_transforms(
+                "A.users",
+                "users",
+                &["id".to_string(), "email".to_string()],
+            );
+
+            let keys = transform_keys(&s, "A.users");
+            assert_eq!(keys.len(), 1);
+            assert!(keys.contains(&"email".to_string()));
+        }
     }
 }

--- a/datanymizer_engine/src/settings/table.rs
+++ b/datanymizer_engine/src/settings/table.rs
@@ -4,7 +4,7 @@ use crate::Transformers;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-type Rules = HashMap<String, Transformers>;
+pub type Rules = HashMap<String, Transformers>;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Query {
@@ -18,9 +18,12 @@ pub struct Query {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Table {
-    /// Table name
+    /// Table name (exact or wildcard pattern like "public.*")
+    #[serde(default)]
     pub name: String,
-    /// Rule set for columns
+    /// Alternative: list of table name patterns (e.g. ["A.*", "B.*"])
+    pub names: Option<Vec<String>>,
+    /// Rule set for columns (keys are exact column names)
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub rules: Rules,
     /// Order of applying rules. All rules not listed are placed at the beginning
@@ -33,6 +36,25 @@ pub struct Table {
 }
 
 impl Table {
+    /// Returns the list of table name patterns this config entry matches against.
+    pub fn patterns(&self) -> Vec<&str> {
+        if let Some(names) = &self.names {
+            names.iter().map(|s| s.as_str()).collect()
+        } else {
+            vec![&self.name]
+        }
+    }
+
+    /// Returns true if any pattern contains wildcard characters (* or ?).
+    pub fn has_wildcards(&self) -> bool {
+        let is_wild = |s: &str| s.contains('*') || s.contains('?');
+        if let Some(names) = &self.names {
+            names.iter().any(|p| is_wild(p))
+        } else {
+            is_wild(&self.name)
+        }
+    }
+
     pub fn transform_list(&self) -> TransformList {
         let explicit_rule_order = self.rule_order.clone().unwrap_or_default();
         let mut transform_list: TransformList = self

--- a/datanymizer_engine/src/transformer/mod.rs
+++ b/datanymizer_engine/src/transformer/mod.rs
@@ -32,6 +32,7 @@ pub struct TransformError {
 #[serde(default)]
 pub struct TransformerDefaults {
     pub locale: LocaleConfig,
+    pub preserve_null: bool,
 }
 
 #[derive(Default)]

--- a/datanymizer_engine/src/transformers/fk/mod.rs
+++ b/datanymizer_engine/src/transformers/fk/mod.rs
@@ -502,6 +502,7 @@ mod tests {
             t.init(&TransformerInitContext::from_defaults(
                 TransformerDefaults {
                     locale: LocaleConfig::RU,
+                    ..Default::default()
                 },
             ));
             assert_eq!(t.locale, Some(LocaleConfig::RU));
@@ -515,6 +516,7 @@ mod tests {
             t.init(&TransformerInitContext::from_defaults(
                 TransformerDefaults {
                     locale: LocaleConfig::RU,
+                    ..Default::default()
                 },
             ));
             assert_eq!(t.locale, Some(LocaleConfig::EN));

--- a/datanymizer_engine/src/transformers/internet/email.rs
+++ b/datanymizer_engine/src/transformers/internet/email.rs
@@ -308,7 +308,10 @@ mod tests {
                           "#;
         let mut transformer: EmailTransformer = serde_yaml::from_str(config).unwrap();
         let locale = LocaleConfig::RU;
-        let ctx = TransformerInitContext::from_defaults(TransformerDefaults { locale });
+        let ctx = TransformerInitContext::from_defaults(TransformerDefaults {
+            locale,
+            ..Default::default()
+        });
 
         Transformer::init(&mut transformer, &ctx);
 

--- a/datanymizer_engine/src/transformers/mod.rs
+++ b/datanymizer_engine/src/transformers/mod.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 mod none;
 pub use none::NoneTransformer;
 
+mod null;
+pub use null::NullTransformer;
+
 mod internet;
 pub use internet::{EmailKind, EmailTransformer, IpTransformer, PasswordTransformer};
 
@@ -78,6 +81,7 @@ macro_rules! define_transformers_enum {
 
 define_transformers_enum![
     ("none", None, NoneTransformer),
+    ("null", Null, NullTransformer),
     ("email", Email, EmailTransformer),
     ("ip", Ip, IpTransformer),
     ("phone", Phone, PhoneTransformer),

--- a/datanymizer_engine/src/transformers/mod.rs
+++ b/datanymizer_engine/src/transformers/mod.rs
@@ -198,6 +198,7 @@ mod tests {
         ts.init(&TransformerInitContext::from_defaults(
             TransformerDefaults {
                 locale: LocaleConfig::RU,
+                ..Default::default()
             },
         ));
 

--- a/datanymizer_engine/src/transformers/null.rs
+++ b/datanymizer_engine/src/transformers/null.rs
@@ -1,0 +1,33 @@
+use crate::transformer::{TransformContext, TransformResult, TransformResultHelper, Transformer};
+use serde::{Deserialize, Serialize};
+
+/// Sets the field value to NULL (`\N` in PostgreSQL COPY format).
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct NullTransformer;
+
+impl Transformer for NullTransformer {
+    fn transform(
+        &self,
+        _field_name: &str,
+        _field_value: &str,
+        _ctx: &Option<TransformContext>,
+    ) -> TransformResult {
+        TransformResult::present("\\N")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sets_value_to_null() {
+        let transformer: NullTransformer = serde_yaml::from_str("~").unwrap();
+        let value = transformer
+            .transform("field", "some_value", &None)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(value, "\\N");
+    }
+}

--- a/datanymizer_engine/src/transformers/pipeline.rs
+++ b/datanymizer_engine/src/transformers/pipeline.rs
@@ -85,6 +85,7 @@ mod tests {
         t.init(&TransformerInitContext::from_defaults(
             TransformerDefaults {
                 locale: LocaleConfig::RU,
+                ..Default::default()
             },
         ));
 

--- a/datanymizer_engine/src/transformers/template/mod.rs
+++ b/datanymizer_engine/src/transformers/template/mod.rs
@@ -273,6 +273,7 @@ mod tests {
         t.init(&TransformerInitContext::from_defaults(
             TransformerDefaults {
                 locale: LocaleConfig::RU,
+                ..Default::default()
             },
         ));
 

--- a/datanymizer_engine/tests/new_fk_transformer.rs
+++ b/datanymizer_engine/tests/new_fk_transformer.rs
@@ -74,6 +74,7 @@ fn set_defaults() {
     t.init(&TransformerInitContext::from_defaults(
         TransformerDefaults {
             locale: LocaleConfig::RU,
+            ..Default::default()
         },
     ));
     assert_eq!(t.locale(), Some(LocaleConfig::RU));

--- a/docs/config.md
+++ b/docs/config.md
@@ -676,20 +676,25 @@ For additional information please refer to the [template](transformers.md#templa
 
 ## default
 
-| Section       | Mandatory | YAML type | Description
-|---            |---        |---        |---
-| `locale`      | no        | text      | The default locale for transformers
+| Section          | Mandatory | YAML type | Description
+|---               |---        |---        |---
+| `locale`         | no        | text      | The default locale for transformers
+| `preserve_null`  | no        | boolean   | When `true`, NULL values (`\N`) are preserved instead of transformed (default: `false`)
 
 Supported locales are `EN` (the default one), `ZH_TW` (traditional chinese) and `RU` (translation in progress).
 We plan to support more locales in the future.
 
 You can override the locale for each transformer (rule) in its options. Some transformers are not affected by locale.
 
+By default, NULL values (represented as `\N` in PostgreSQL COPY format) are passed to transformers
+and replaced with generated data. Set `preserve_null: true` to keep NULLs as-is globally.
+
 Example:
 
 ```yaml
 default:
   locale: RU
+  preserve_null: true
 ```
 
 ## filter

--- a/docs/config.md
+++ b/docs/config.md
@@ -227,20 +227,90 @@ tables:
 
 | Section                   | Mandatory | YAML type  | Description
 |---                        |---        |---         |---
-| `name`                    | yes       | text       | The table name in the database
+| `name`                    | no*       | text       | The table name (exact or wildcard pattern)
+| `names`                   | no*       | list       | A list of table name patterns
 | [rules](#rules)           | yes       | dictionary | Anonymization rules for this table (the column names are the dictionary keys)
 | [rule_order](#rule_order) | no        | list       | An order of rule execution
-| [query](#query)           | no        | dictionary | Conditions for SQL queries for dumping data 
+| [query](#query)           | no        | dictionary | Conditions for SQL queries for dumping data
 | [asserts](#asserts)       | no        | list       | SQL assertions executed for this table before dumping starts
+
+\* Either `name` or `names` should be provided.
 
 You can use table names with schema (e.g. `public.users`) or without it (just `users`). In the latter case, this means
 that the rules will be applied to the `users` table in any schema.
+
+#### Wildcard patterns in table names
+
+Table names (in both `name` and `names`) support wildcard patterns:
+
+* `*` matches arbitrary many (including zero) occurrences of any character
+* `?` matches exactly one occurrence of any character
+
+##### Wildcard table names
+
+Use wildcards in `name` to match multiple tables:
+
+```yaml
+tables:
+  # Match all tables in the public schema
+  - name: "public.*"
+    rules:
+      email:
+        email: {}
+```
+
+##### The `names` field
+
+Use `names` to apply the same rules to tables matching any of several patterns:
+
+```yaml
+tables:
+  # Apply to all tables in schemas A and B
+  - names: ["A.*", "B.*"]
+    rules:
+      email:
+        email: {}
+```
+
+When a table is matched via a wildcard pattern, exact column names that don't exist in that table
+are silently skipped — the same rule set may apply to tables with different schemas.
+
+When a table is matched exactly (`name: users` or a non-wildcard entry in `names`), exact column
+names that don't exist produce an error, catching typos.
+
+##### Precedence
+
+When multiple table entries could match, the most specific one wins:
+
+1. **Exact table name** (`public.users`) always takes priority over wildcards
+2. **First matching wildcard entry** wins when multiple wildcard entries could match (config order matters)
+
+Example:
+
+```yaml
+tables:
+  # Wildcard: applies to all public tables
+  - name: "public.*"
+    rules:
+      email:
+        email: {}
+
+  # Exact: overrides the wildcard for this specific table
+  - name: public.users
+    rules:
+      email:
+        email:
+          uniq: true
+```
+
+In this example, `public.users` uses the exact entry (with `uniq: true`), while all other
+`public.*` tables use the wildcard entry.
 
 #### rules
 
 Anonymization rules (we call them `transformers`) for the table columns.
 
-Dictionary keys are the column names.
+Dictionary keys are the exact column names.
 Each value contains an anonymizing configuration for column (a name of transformer - an address, a company name, a person name, 
 some template, etc, with its options).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -254,6 +254,7 @@ some template, etc, with its options).
 | `city`                         | City names generator                                                          |
 | `phone`                        | Generate random phone with different `format`                                 |
 | `pipeline`                     | Use pipeline to generate more complicated values                              |
+| `null`                         | Sets the field value to NULL                                                  |
 | `capitalize`                   | Like filter, it capitalizes input value                                       |
 | `template`                     | Template engine for generate random text with included rules                  |
 | `digit`                        | Random digit (in range `0..9`), localized                                               |

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -220,6 +220,18 @@ Example:
 none: ~
 ```
 
+#### null
+
+Sets the field value to NULL (`\N` in PostgreSQL COPY format).
+This is useful when you want to clear a column during anonymization.
+
+Example:
+
+```yaml
+# You should use ~ (the null value in YAML) for this transformer
+null: ~
+```
+
 #### pipeline
 
 You can use pipelines with complicated rules to generate more difficult values.


### PR DESCRIPTION
> [!NOTE]  
> This PR was assisted by AI, and reviewed by me.

## Summary

- Add `null` transformer that sets field values to NULL (`\N` in PostgreSQL COPY format)
- Useful for clearing sensitive columns during anonymization without generating replacement data

Fix #53

## Config example

```yaml
tables:
  - name: users
    rules:
      secret_notes:
        null: ~
```

#### ✓ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/datanymizer/datanymizer/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [x] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
